### PR TITLE
Change approach to `full` mixin

### DIFF
--- a/sass/susy/_grid.scss
+++ b/sass/susy/_grid.scss
@@ -107,6 +107,7 @@ $omega-float        : opposite-position($from-direction)    !default;
   width: columns($n, $context);
   // the right gutter is added as a percentage of the context
   margin-#{$to}: gutter($context);
+  margin-#{$from}: 0;
 }
 
 // @include `reset-column` to reset a column element to default block behavior
@@ -130,12 +131,14 @@ $omega-float        : opposite-position($from-direction)    !default;
 @mixin full(
   $nested: false
 ) {
-  clear: both;
-  @if not $nested {
-    margin: {
-      left: side-gutter();
-      right: side-gutter();
-    }
+  @if $nested {
+    @include float(left); // direction doesn't matter since it's 100% width
+    width: 100%;
+    margin-left: 0;
+    margin-right: 0;
+  } @else {
+    @include columns($total-cols);
+    @include alpha;
   }
 }
 


### PR DESCRIPTION
If you include the `full` mixin on an element, and then later override it with the `columns` mixin, the element inherits a wrong margin on one side and a wrongful `clear: both;`. Demonstration: http://tinkerbin.com/PXGxcUMI (Tinkerbin apparently doesn't save the code's format, you'll have to make sure 'haml' and 'sass css' are selected and reload).

I ran into this problem when declaring something as full-width for mobile, then making it a column inside of a media query.

Demonstration of my proposed solution: http://tinkerbin.com/oZNdLp0e

The only thing that really bothers me about this solution is that using `columns` and `alpha` together would result in two `margin-left` declarations in a single style block. Interested to hear your thoughts.

Thanks!

_Edit_ - Maybe if this doesn't suit you, a `reset-full` mixin, like `reset-column`, might be in order?
