### PR TITLE
Column counter with auto insertion of Omega

### DIFF
--- a/sass/susy/_grid.scss
+++ b/sass/susy/_grid.scss
@@ -78,14 +78,30 @@
 //          : Context is required on any nested elements.
 //          : Context MUST NOT be declared on a root element.
 // $from    : The start direction of your layout (e.g. 'left' for ltr languages)
+
+$column-counter: 0;
+
 @mixin columns(
   $columns,
   $context  : $total-columns,
-  $from     : $from-direction
+  $from     : $from-direction,
+  $counter  : $column-counter
 ) {
   $to       : opposite-position($from);
   $pos      : split-columns-value($columns,position);
   $cols     : split-columns-value($columns,columns);
+  
+  // Add columns to the counter
+  $column-counter: $counter + $columns;  
+  
+  // Apply counter logic for Omega
+  @if $column-counter >= $context {
+    @if $auto-omega {
+      $pos: 'omega';
+    }
+    // Reset counter
+    $column-counter: 0;
+  }
   
   width: columns($cols, $context);
 

--- a/sass/susy/_settings.scss
+++ b/sass/susy/_settings.scss
@@ -23,6 +23,10 @@ $from-direction     : left            !default;
 // The direction that +omega elements are floated by deafult.
 $omega-float        : opposite-position($from-direction)    !default;
 
+// Auto Omega insertion:
+// Automatically add Omega to the last colum. This assumes mixins are in markup order.
+$auto-omega         : false           !default;
+
 // Container Width:
 // Override the total width of your grid, using any length (50em, 75%, etc.)
 $container-width    : false           !default;


### PR DESCRIPTION
Added a grid counter so the mixing is aware of where a column falls in
the progression. This allows for Omega to be inserted automatically
when writing mixing in markup order.

see issue #35
