### PR TITLE
Add a site that's using Susy

### DIFF
--- a/docs/source/sites-using-susy.html.md
+++ b/docs/source/sites-using-susy.html.md
@@ -14,5 +14,6 @@ title: Sites using Susy
 - [Volunteer Center Northumberland](https://volunteeringnorthumberland.org.uk/)
 - [Rita Konig](http://ritakonig.com/)
 - [Concordia discors](http://www.ffzg.unizg.hr/zbor/)
+- [Waldorf camp](http://waldorfcamp.net/)
 
 Have a site to add? [Let us know](http://twitter.com/compasssusy/) or [fork and add your site on GitHub](https://github.com/ericam/susy).


### PR DESCRIPTION
I added a responsive site I made using the awesome new Susy. Question,
what about the source code? I have it on GitHub, maybe people will want to
see **how** Susy was used, rather than just looking at the end result.
Should I link it somewhere?
