### PR TITLE
Wrong link in the footer

### DIFF
--- a/docs/source/partials/_contentinfo.haml
+++ b/docs/source/partials/_contentinfo.haml
@@ -31,7 +31,7 @@
       <a href="http://github.com/ericam">Eric A. Meyer</a>
       <span class="amp">&</span> <a href="http://oddbird.net">OddBird</a>,
       and is maintained with the help of
-      <a href="http://www.dannypose.com">Danny Palmer</a>,
+      <a href="http://www.dannyprose.com">Danny Palmer</a>,
       and a number of wonderful
       <a href="https://github.com/ericam/susy/graphs/contributors">contributors</a>.
       <a href="http://github.com/ericam/susy/">Get involved</a>!


### PR DESCRIPTION
The link is incorrect. http://www.dannyprose.com is the right website of @dannyprose.
