### PR TITLE
Error in Magic Demo > .contentinfo margin.

### DIFF
--- a/docs/source/demos/magic.html.md
+++ b/docs/source/demos/magic.html.md
@@ -92,7 +92,7 @@ and add it back in as padding to the footer:
 
     :::scss
     .contentinfo {
-      margin: 0 - $grid-padding;
+      margin: 0 0 - $grid-padding;
       padding: 0 $grid-padding;
     }
 
@@ -300,7 +300,7 @@ without doing any math at all:
 
     .contentinfo {
       clear: both;
-      margin: 0 - $grid-padding;
+      margin: 0 0 - $grid-padding;
       padding: 0 $grid-padding;
       @include at-breakpoint($break) {
         margin: 0;


### PR DESCRIPTION
Fixed typo in 2 places for .contentinfo margin.  The current version sets the top and bottom margins to negative $grid-padding. They should be 0.
