### PR TITLE
Removed 'sudo' in 'sudo gem install'

### DIFF
--- a/docs/source/guides/getting-started.html.md
+++ b/docs/source/guides/getting-started.html.md
@@ -31,7 +31,7 @@ Install from the command line:
 
     :::bash
     # command line
-    sudo gem install susy
+    gem install susy
 
 Create a new [Compass][compass] project:
 


### PR DESCRIPTION
On the getting-started page (http://susy.oddbird.net/guides/getting-started/) sudo is used to install susy. In my opinion you should not encourage people to use sudo to install gems. (they should use rvm for example)
