### PR TITLE
Update sass/susy/_support.scss

### DIFF
--- a/sass/susy/_support.scss
+++ b/sass/susy/_support.scss
@@ -1,3 +1,5 @@
+@charset "UTF-8";
+
 // @@@ These helpers only live here until they land in Compass.
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
This file is using non-ASCII dash characters (line 13-20).  It
should propagate that fact but it does not.  In my setup using
compass with Assetic the render process fails claiming the encounter
with an invalid ASCII character:

error assetic_compasslUhjQO.scss
  (Line 13 of _support.scss: Invalid US-ASCII character "\xE2")
