### PR TITLE
span-columns-fixed

### DIFF
--- a/sass/susy/_functions.scss
+++ b/sass/susy/_functions.scss
@@ -79,18 +79,20 @@ $rem-with-px-fallback               : true !default;
 //  $context  : The grid context in columns, if nested.
 @function columns(
   $columns,
-  $context : $total-columns
+  $context : $total-columns,
+  $fixed: false
 ) {
-  @return relative-width(columns-width($columns), $context);
+  @return if($fixed, fixed-width(columns-width($columns), $context), relative-width(columns-width($columns), $context));
 }
 
 // Return the percentage width of a single gutter in a given 'context'.
 //
 //  $context  : The grid context in columns, if nested.
 @function gutter(
-  $context : $total-columns
+  $context : $total-columns,
+  $fixed: false
 ) {
-  @return relative-width($gutter-width, $context);
+  @return if($fixed, fixed-width($gutter-width, $context), relative-width($gutter-width, $context));
 }
 
 // Return the percentage width of a given value in a given 'context'.
@@ -102,6 +104,17 @@ $rem-with-px-fallback               : true !default;
   $context : $total-columns
 ) {
   @return percentage($width / columns-width($context));
+}
+
+// Return the fixed width of a given value in a given 'context'.
+//
+//  $width    : Any given width value.
+//  $context  : The grid context in columns, if nested.
+@function fixed-width(
+  $width,
+  $context : $total-columns
+) {
+  @return $width;
 }
 
 // Return the total space occupied by multiple columns and associated gutters.

--- a/sass/susy/_grid.scss
+++ b/sass/susy/_grid.scss
@@ -110,13 +110,14 @@
   $columns,
   $context       : $total-columns,
   $padding       : false,
-  $from          : $from-direction
+  $from          : $from-direction,
+  $fixed       : false
 ) {
   $to       : opposite-position($from);
   $pos      : split-columns-value($columns,position);
   $cols     : split-columns-value($columns,columns);
-  $pad-from : relative-width(0 * $gutter-width, $context);
-  $pad-to   : relative-width(0 * $gutter-width, $context);
+  $pad-from : if($fixed, fixed-width(0 * $gutter-width, $context), relative-width(0 * $gutter-width, $context));
+  $pad-to   : if($fixed, fixed-width(0 * $gutter-width, $context), relative-width(0 * $gutter-width, $context));
 
   @if $padding != false {
     $pad-from : nth($padding, 1);
@@ -127,24 +128,34 @@
       $pad-to: $pad-from;
     }
 
-    $pad-from : relative-width($pad-from, $context);
-    $pad-to   : relative-width($pad-to, $context);
+    $pad-from : if($fixed, fixed-width($pad-from, $context), relative-width($pad-from, $context));
+    $pad-to   : if($fixed, fixed-width($pad-to, $context), relative-width($pad-to, $context));
 
     padding-#{$from}: $pad-from;
     padding-#{$to}: $pad-to;
   }
 
-  width: columns($cols, $context) - if($border-box-sizing, 0, $pad-to + $pad-from);
+  width: columns($cols, $context, $fixed) - if($border-box-sizing, 0, $pad-to + $pad-from);
 
   @if ($pos == 'omega') {
     @include omega($from);
   } @else {
     float: $from;
-    margin-#{$to}: gutter($context);
+    margin-#{$to}: gutter($context, $fixed);
     @if $legacy-support-for-ie6 {
       display: inline;
     }
   }
+}
+
+// Wrapper for span-columns mixin that forces fixed units
+@mixin span-columns-fixed(
+  $columns,
+  $context       : $total-columns,
+  $padding       : false,
+  $from          : $from-direction
+) {
+  @include span-columns($columns, $context, $padding, $from, true);
 }
 
 // Apply to elements spanning the last column, to account for the page edge.


### PR DESCRIPTION
Added span-columns-fixed mixin to allow use of px instead of %
- We found issues with sub-pixel rendering using percentages so decided to use px instead.
- Adds new mixin for span-columns-fixed which is just a wrapper to span-columns with the $fixed flag set to true
