### PR TITLE
Update Modular Scale - eliminated sass-cache "cant dump anonymous class" error from issue 149.

### DIFF
--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -5,7 +5,7 @@ gem "sass", "~> 3.2.3"
 gem "compass", :git => "git://github.com/chriseppstein/compass.git", :branch => "master"
 gem "susy", :path => "../"
 
-gem "modular-scale", "~> 1.0.2"
+gem "modular-scale", "~> 1.0.3"
 gem "redcarpet"
 gem "rack-codehighlighter", :git => "git://github.com/wbzyl/rack-codehighlighter.git"
 gem "pygments.rb"

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -76,7 +76,7 @@ GEM
       middleman-more (>= 3.0.1)
       sprockets (~> 2.1, < 2.5)
       sprockets-sass (~> 0.9.0)
-    modular-scale (1.0.2)
+    modular-scale (1.0.3)
       compass (>= 0.11.5)
       sassy-math (>= 1.2)
     multi_json (1.5.0)
@@ -134,7 +134,7 @@ PLATFORMS
 DEPENDENCIES
   compass!
   middleman (~> 3.0.7)
-  modular-scale (~> 1.0.2)
+  modular-scale (~> 1.0.3)
   pygments.rb
   rack-codehighlighter!
   redcarpet


### PR DESCRIPTION
See ericam/susy/issues/149.

```
Warning. Error encountered while saving cache ./.sass-cache/d175c599ab343807958701afee8ac8957af15d94/_modular-scale.sassc: can't dump anonymous class #<Class:0x007f97f580fcc0>
```

With [Modular Scale](/scottkellum/modular-scale) version 1.0.3, the problem no longer exists for me.
