### PR TITLE
Updated the documentation for the bleed mixin (removed duplication of last parameter) based on the included code.

### DIFF
--- a/docs/source/guides/reference.html.md
+++ b/docs/source/guides/reference.html.md
@@ -433,8 +433,6 @@ so that its background "bleeds" outside its natural position.
   Default: `left right`.
 - `<$style>`: Optionally return `static` lengths for grid calculations.
   Default: `$container-style`.
-- `<$style>`: Optionally return `static` lengths for grid calculations.
-  Default: `$container-style`.
 
 ### <a href="#ref-helper-margin" id="ref-helper-margin">Margin Mixins</a>
 


### PR DESCRIPTION
Based on:

```
@mixin bleed(
  $width: $grid-padding,
  $sides: left right,
  $style: fix-static-misalignment()
)
```
