### PR TITLE
Fixed for Isolate Grid

### DIFF
--- a/sass/susy/_isolation.scss
+++ b/sass/susy/_isolation.scss
@@ -42,6 +42,7 @@
     &:#{format-nth($nth,$selector)} {
       margin-#{$from}: space($location - 1, $context, $style);
       @if $location == 1 { clear: $from; }
+      @else { clear: none; }
 
       $location: $location + $columns;
       @if $location > $context { $location: 1; }


### PR DESCRIPTION
Fixed a problem with isolate grids when you have them inside of at-breakpoints.

Clears from smaller grids would effect larger isolated grids if they are structured via breakpoints.

Ex:

```
    @include isolate-grid(3, 6);
    @include at-breakpoint(30em $small-break) { @include isolate-grid(2,4); }
    @include at-breakpoint(50em $middle-break) { @include isolate-grid(2,6); }
    @include at-breakpoint(60em $large-break) { @include isolate-grid(2,8); }
```
