### PR TITLE
Update copyright year 2012 -> 2013

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2012, Eric Meyer
+Copyright (c) 2013, Eric Meyer
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/docs/source/partials/_contentinfo.haml
+++ b/docs/source/partials/_contentinfo.haml
@@ -38,7 +38,7 @@
 
   <p class="license">
     <a href="https://github.com/ericam/susy/blob/master/LICENSE.txt">
-      Copyright &copy; 2012
+      Copyright &copy; 2013
     </a>
     <a href="http://eric.andmeyer.com/">Eric A. Meyer</a><br />
     An <a href="http://oddbird.net/">OddBird</a> project.


### PR DESCRIPTION
It has been 2013 for a while now, I think we can safely bump the year in
the footer of the docs and the license.
