### PR TITLE
Mark global variable assignments

### DIFF
--- a/sass/susy/language/shared/_settings.scss
+++ b/sass/susy/language/shared/_settings.scss
@@ -42,22 +42,22 @@ $show-grids           : show-columns    !default;
   $grid                 : get-adjusted-grid($grid, $clean);
 
   // get values
-  $columns              : get-setting(columns, $grid);
-  $gutters              : get-setting(gutters, $grid);
-  $container            : get-setting(container, $grid);
-  $column-width         : get-setting(column-width, $grid);
-  $layout-math          : get-setting(layout-math, $grid);
-  $layout-method        : get-setting(layout-method, $grid);
+  $columns              : get-setting(columns, $grid) !global;
+  $gutters              : get-setting(gutters, $grid) !global;
+  $container            : get-setting(container, $grid) !global;
+  $column-width         : get-setting(column-width, $grid) !global;
+  $layout-math          : get-setting(layout-math, $grid) !global;
+  $layout-method        : get-setting(layout-method, $grid) !global;
 
-  $flow                 : get-setting(flow, $grid);
-  $gutter-position      : get-setting(gutter-position, $grid);
-  $container-position   : get-setting(container-position, $grid);
-  $show-grids           : get-setting(show-grids, $grid);
-  $box                  : get-setting(box-sizing, $grid);
+  $flow                 : get-setting(flow, $grid) !global;
+  $gutter-position      : get-setting(gutter-position, $grid) !global;
+  $container-position   : get-setting(container-position, $grid) !global;
+  $show-grids           : get-setting(show-grids, $grid) !global;
+  $box                  : get-setting(box-sizing, $grid) !global;
 
-  $container            : get-setting(container, $grid);
-  $column-width         : get-setting(column-width, $grid);
-  $box-sizing           : get-setting(box-sizing, $grid);
+  $container            : get-setting(container, $grid) !global;
+  $column-width         : get-setting(column-width, $grid) !global;
+  $box-sizing           : get-setting(box-sizing, $grid) !global;
 }
 
 // Use Grid


### PR DESCRIPTION
These are all definitely assignments to global variables (that's the point of this mixin), so I've changed them. But when I started looking through the deprecation warnings, most of them seemed like the right thing. That is, most of the warnings are about variables called either "$box" or "$columns" that _should_ be locals based on what the code seems to be doing. So marking those global would probably be a mistake. I think part of the issue is that in many cases it is not clear whether the variable in question is a global, or a local with the same name as a global. 

A good example is the "nested" mixin, in _context.scss. Should the variable "$columns" in this mixin be used as a global, or a local? It's unclear, because this mixin calls @content, and I am unsure whether a variable scoped to the nested mixin would be visible to the @content block, or it would need to be global.

Please let me know if I can be of more help than this. I don't feel like I achieved much here.
