### PR TITLE
Fixed SASS_PATH environment variable

### DIFF
--- a/lib/susy.rb
+++ b/lib/susy.rb
@@ -4,9 +4,9 @@ begin
   Compass::Frameworks.register('susy', :stylesheets_directory => susy_stylesheets_path)
 rescue LoadError
   # compass not found, register on the Sass path via the environment.
-  if ENV.has_key?("SASSPATH")
-    ENV["SASSPATH"] = ENV["SASSPATH"] + File::PATH_SEPARATOR + susy_stylesheets_path
+  if ENV.has_key?("SASS_PATH")
+    ENV["SASS_PATH"] = ENV["SASS_PATH"] + File::PATH_SEPARATOR + susy_stylesheets_path
   else
-    ENV["SASSPATH"] = susy_stylesheets_path
+    ENV["SASS_PATH"] = susy_stylesheets_path
   end
 end


### PR DESCRIPTION
Make it compatible with sass and sass-rails gems.

After changing the environment variables from SASSPATH
to SASS_PATH, Susy 2 worked flawlessly on Rails 4 and
Sinatra applications, without the compass dependency.
