### PR TITLE
full() resets margins when using isolation

### DIFF
--- a/sass/susy/language/susy/_rows.scss
+++ b/sass/susy/language/susy/_rows.scss
@@ -37,6 +37,10 @@
   @if is-split($span) and not susy-get(is-container, $span) {
     @include gutters($span);
   }
+  @if susy-get(layout-method, $span) == isolate {
+    margin-left: auto;
+    margin-right: auto;
+  }
   float: none;
   width: auto;
 }


### PR DESCRIPTION
For when full() is used in a media-query to override a span()ed element (using isolate layout-method)
