### PR TITLE
Add margins only if $location is provided

### DIFF
--- a/sass/susy/language/susy/_span.scss
+++ b/sass/susy/language/susy/_span.scss
@@ -38,6 +38,7 @@
   $span
 ) {
   $split-container  : if(is-split($span) and susy-get(is-container, $span), true, false);
+  $location         : susy-get(location, $span);
 
   $float            : from;
   $padding-before   : null;
@@ -65,20 +66,17 @@
   }
 
   // special margin handling
-  @if susy-get(layout-method, $span) == isolate {
+  @if susy-get(layout-method, $span) == isolate and $location {
     $margin-before: get-isolation($span);
     $margin-after: -100%;
   } @else {
-    $location: susy-get(location, $span);
-    @if $location {
-      $last: is-last(susy-get(span, $span), $location, susy-get(columns, $span));
-      $is-split: is-split($span);
-      @if $last {
-        $float: susy-get(last-flow, $span);
-        $margin-after: if($is-split, $margin-after, null);
-      } @else if is-first($location) {
-        $margin-before: if($is-split, $margin-before, null);
-      }
+    $last: is-last(susy-get(span, $span), $location, susy-get(columns, $span));
+    $is-split: is-split($span);
+    @if $last {
+      $float: susy-get(last-flow, $span);
+      $margin-after: if($is-split, $margin-after, null);
+    } @else if is-first($location) {
+      $margin-before: if($is-split, $margin-before, null);
     }
   }
 


### PR DESCRIPTION
Before this commit, when using isolation, you were forced to pass a $location to span(), yet if you passed 0 you got no margin-left (in ltr) in return, this commit:
- Allows you to omit the $location argument if you don't want to mess with source order (leaving you with the standard float method, if I understand correctly).
- Allows you to pass 0px/% (can't be unitless, possibly a bug) and get the appropriate margin in return.

This works fine in my tests, but please run a few more to make sure I don't introduce any regression.
