### PR TITLE
Update Twitter links compasssusy -> sasssusy

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ we just do the math and get out of your way.
 - [Tutorial](http://susy.oddbird.net/guides/getting-started/)
 - [Reference](http://susy.oddbird.net/guides/reference/)
 - [Sites using Susy](http://susy.oddbird.net/sites-using-susy/)
-- [Twitter @CompassSusy](http://twitter.com/compasssusy/)
+- [Twitter @SassSusy](http://twitter.com/sasssusy/)
 
 ## Contributing
 

--- a/docs/source/partials/_navigation.haml
+++ b/docs/source/partials/_navigation.haml
@@ -12,4 +12,4 @@
   %li
     %a{ :href => "http://stackoverflow.com/questions/tagged/susy-compass"} Support
   %li
-    %a{ :href => "http://twitter.com/compasssusy/" } Twitter
+    %a{ :href => "http://twitter.com/sasssusy/" } Twitter


### PR DESCRIPTION
@CompassSusy no longer exists. @SassSusy is the new Twitter handle[1](https://twitter.com/SassSusy/status/416029969697878016).
This commit updates the links pointing to the old Twitter account.
