### PR TITLE
Updates sites-using-susy.html.md with SmithsonianMag.com

### DIFF
--- a/docs/source/sites-using-susy.html.md
+++ b/docs/source/sites-using-susy.html.md
@@ -43,6 +43,7 @@ title: Sites using Susy
 - [Andrew Philip Clark](http://andrewphilipclark.com)
 - [Uncorked Studios](http://uncorkedstudios.com/)
 - [Vermont Brewers Association](http://www.vermontbrewers.com)[[source](https://github.com/rHoover/vermont-brewers)]
+- [Smithsonian Magazine](http://smithsonianmag.com)
 
 Have a site to add? [Let us know](http://twitter.com/compasssusy) or [fork and add your site on GitHub](https://github.com/ericam/susy).
 


### PR DESCRIPTION
Lincoln Loop recently deployed SmithsonianMag.com, built on Susy.
