### PR TITLE
Use Sass load path when Compass is not previously required

### DIFF
--- a/lib/susy.rb
+++ b/lib/susy.rb
@@ -1,10 +1,10 @@
 base_directory  = File.expand_path(File.join(File.dirname(__FILE__), '..'))
 susy_stylesheets_path = File.join(base_directory, 'sass')
 susy_templates_path = File.join(base_directory, 'templates')
-begin
-  require 'compass'
+
+if (defined? Compass)
   Compass::Frameworks.register('susy', :stylesheets_directory => susy_stylesheets_path, :templates_directory => susy_templates_path)
-rescue LoadError
+else
   # compass not found, register on the Sass path via the environment.
   if ENV.has_key?("SASS_PATH")
     ENV["SASS_PATH"] = ENV["SASS_PATH"] + File::PATH_SEPARATOR + susy_stylesheets_path


### PR DESCRIPTION
Hi,

This PR should fix the issue I reported in #327.

What was happening is that `compass` gem is installed on my machine so `require 'compass'` wasn't firing the `LoadError` and susy paths were added to `compass` (which wasn't used) instead of being included in the `SASS_PATH` environment variable.

With this fix, it now checks if Compass was required before, in this case, it loads `susy` paths in Compass, otherwise it adds it to `SASS_PATH`.

Works fine in local with `sass` compiler and `compass` compiler.

Let me know what you think,

Thanks!
