### PR TITLE
Update install.rst

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -45,7 +45,7 @@ Compass
 -------
 
 If you want to use Susy with `Compass`_,
-start by `installing Compass`_.
+start by `installing the pre-release version of Compass`_.
 
 Create a new Compass project:
 
@@ -55,7 +55,7 @@ Create a new Compass project:
   compass create --using susy <project name>
 
 .. _Compass: http://compass-style.org/
-.. _installing Compass: http://compass-style.org/install/
+.. _installing the pre-release version of Compass: http://beta.compass-style.org/install/
 
 
 Grunt (and Yeoman)


### PR DESCRIPTION
Added text and link to pre-release version of Compass under 'Compass' section of Install.

Users of version < 1.0 of Compass will encounter the following error when installing: 'No such framework: "susy"'
