### PR TITLE
Fix documentation typo

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -421,7 +421,7 @@ Align the container relative to it's parent element
   If one length is given,
   it will be applied to both side margins,
   to offset the container from the edges of the viewport.
-  If to values are given,
+  If two values are given,
   they will be used as ``left`` and ``right`` margins respectively.
 
 


### PR DESCRIPTION
- Change "to" to "two" in settings documentation for container position
