### PR TITLE
Fix documentation typo

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -439,7 +439,7 @@ Establish the column-count and arrangement for a grid.
   :key: ``columns``
   :scope: global, local
   :options: ``<number>`` | ``<list>``
-  :default: ``12``
+  :default: ``4``
 
 ``<number>``
   The number of columns in your layout.


### PR DESCRIPTION
Default for columns should be 4 instead of 12

Signed-off-by: Zell Liew zellwk@gmail.com
