### PR TITLE
Add `breakpoint` value to settings maps, add simple-susy-breakpoint mixin

### DIFF
--- a/sass/susy/language/susy/_breakpoint-plugin.scss
+++ b/sass/susy/language/susy/_breakpoint-plugin.scss
@@ -32,6 +32,8 @@
 // - $config    : a valid $susy config map
 // - $columns   : either a value/list that's valid for span() mixin, or the word 'container'
 // - $grid      : if true, calls show-grid() mixin if $columns == container
+// Also, this would require a `breakpoint` value in the $config map:
+//   That value would be any valid breakpoint() value/list.
 @mixin simple-susy-breakpoint(
   $config,
   $columns,

--- a/sass/susy/language/susy/_breakpoint-plugin.scss
+++ b/sass/susy/language/susy/_breakpoint-plugin.scss
@@ -30,7 +30,7 @@
 // ---------------
 // Shorten mixin syntax & add `breakpoint` value to $susy maps
 // - $config    : a valid $susy config map
-// - $columns  : either a value/list that's valid for span() mixin, or the word 'container'
+// - $columns   : either a value/list that's valid for span() mixin, or the word 'container'
 // - $grid      : if true, calls show-grid() mixin if $columns == container
 @mixin simple-susy-breakpoint(
   $config,

--- a/sass/susy/language/susy/_breakpoint-plugin.scss
+++ b/sass/susy/language/susy/_breakpoint-plugin.scss
@@ -24,3 +24,32 @@
     @warn "Susy-breakpoint requires the Breakpoint plugin (http://breakpoint-sass.com/)";
   }
 }
+
+
+// Simple Susy Breakpoint
+// ---------------
+// Shorten mixin syntax & add `breakpoint` value to $susy maps
+// - $config    : a valid $susy config map
+// - $columns  : either a value/list that's valid for span() mixin, or the word 'container'
+// - $grid      : if true, calls show-grid() mixin if $columns == container
+@mixin simple-susy-breakpoint(
+  $config,
+  $columns,
+  $grid: false
+) {
+  @if map-get($config, breakpoint) == null {
+    @warn 'The map you specified does not have a breakpoint value.';
+  } @else {
+    $breakpoint: map-get($config, breakpoint);
+    @include susy-breakpoint($breakpoint, $config) {
+      @if $columns == container {
+        @include container;
+        @if $grid == true {
+          @include show-grid;
+        }
+      } @else {
+        @include span($columns);
+      }
+    }
+  }
+}


### PR DESCRIPTION
Here are my thoughts behind this: I'd like to attach breakpoint MQ-data directly to a settings map (yep, that means a tighter integration with Breakpoint). I'd also like to shorten the syntax for generating new grid styles in a new breakpoint context. Rather than:

```
.selector {
  @include susy-breakpoint($mq-data, $small-settings) {
    @include span($span-stuff);
  }
}
```

I'd prefer:

```
.selector {
  @include simple-susy-breakpoint($config, $columns, $grid);
}
```

In the request I've submitted, the `$config` settings map will have a `breakpoint` key that would hold a value/list that's compatible with Breakpoint. The mixin would get that value automatically (I use a settings map per breakpoint if the column count or proportions change responsively), then get either a span value (span, location, layout) or the word `container` and call `span()` or `container()` from `$columns`. If it's a container, the `$grid` parameter would tell the mixin to re-run `show-grids()` at this breakpoint.

Not sold on the name at all - please suggest a better one (or we could work to add this functionality to `susy-breakpoint()` while maintaining backwards-compatibility.

Thanks!