### PR TITLE
No needed semicolon.

### DIFF
--- a/sass/susy/output/shared/_inspect.scss
+++ b/sass/susy/output/shared/_inspect.scss
@@ -19,4 +19,4 @@
   @if $show or susy-get(debug inspect) {
     -susy-#{$mixin}: inspect($inspect);
   }
-};
+}


### PR DESCRIPTION
No needed semicolon which throws error in node libsass sass preprocessor.
/susy/output/shared/inspect:22: invalid top-level expression
