### PR TITLE
SVG instead of Gradient-Background

### DIFF
--- a/sass/susy/language/susy/_background.scss
+++ b/sass/susy/language/susy/_background.scss
@@ -35,22 +35,42 @@ $susy-overlay-grid-head-exists: false;
 @mixin background-grid(
   $grid: $susy
 ) {
-  $inspect  : $grid;
-  $_output  : get-background($grid);
+  
+  $colums-count: susy-count(  susy-get(columns, $grid));
+  $debug-color: susy-get(debug color, $grid);
+  $debug-color-light: lighten($debug-color,10) ;
+  $gutter: gutter($grid);
+ 
+  $svg-grid: '<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">';
+  //Devs
+  $svg-grid : $svg-grid + '<defs>';
+  $svg-grid : $svg-grid + '<linearGradient id="gr" x1="0%" y1="0%" x2="100%" y2="0%">';
+  $svg-grid : $svg-grid + '<stop offset="0%" style="stop-color:#{$debug-color};" />';
+  $svg-grid : $svg-grid + '<stop offset="100%" style="stop-color:#{$debug-color-light};" />';
+  $svg-grid : $svg-grid + '</linearGradient>';
+  
+  @if variable-exists(base-line-height){
 
-  @if length($_output) > 0 {
-    $_flow: susy-get(flow, $grid);
-
-    $_image: ();
-    @each $name, $layer in map-get($_output, image) {
-      $_direction: if($name == baseline, to bottom, to to($_flow));
-      $_image: append($_image, linear-gradient($_direction, $layer), comma);
-    }
-    $_output: map-merge($_output, (image: $_image));
-
-    @include background-grid-output($_output...);
-    @include susy-inspect(background-grid, $inspect);
+    $svg-grid : $svg-grid +'<pattern patternUnits="userSpaceOnUse" id="baseline" width="100%" height="#{$base-line-height}" >';
+    $svg-grid : $svg-grid +'<line x1="-10%" y1="1" x2="110%" y2="1" stroke="#666" stroke-width="0.5"  />';
+    $svg-grid : $svg-grid +'</pattern>';
   }
+  $svg-grid : $svg-grid + '</defs>';
+  @for $i from 1 through $colums-count {
+    $x: isolate($i of $grid);
+    $span: span(1 at $i of $grid);
+    $svg-grid : $svg-grid +  '<rect x="#{$x}" fill="url(#gr)" width="#{$span}" height="100%"/>';
+  }
+  @if variable-exists(base-line-height){
+    $svg-grid : $svg-grid +  '<rect x="0" fill="url(#baseline)" width="100%" height="100%"/>';
+  }
+
+  $svg-grid : $svg-grid +  '</svg>';
+  $data-prefix:"data:image/svg+xml,";
+
+  background-image: url( $data-prefix + html-encode($svg-grid));
+  background-size: 100% 100%;
+  background-position: 0 0;
 }
 
 
@@ -135,239 +155,6 @@ $susy-overlay-grid-head-exists: false;
   right: 0;
   content: " ";
   z-index: 998;
-}
-
-
-// Get Symmetrical Background
-// --------------------------
-// - $grid: <map>
-@function get-background-sym(
-  $grid
-) {
-  $grid           : parse-grid($grid);
-  $_gutters       : susy-get(gutters, $grid);
-  $_column-width  : susy-get(column-width, $grid);
-  $_math          : susy-get(math, $grid);
-
-  $_color         : debug-get(color);
-  $_trans         : transparent;
-  $_light         : lighten($_color, 15%);
-
-  $_end           : 1 + $_gutters;
-  $_after         : percentage(1/$_end);
-  $_stops         : ();
-  $_size          : span(1 $grid wide);
-
-  @if is-inside($grid) {
-    $_stops: $_color, $_light;
-  } @else if is-split($grid) {
-    $_split: $_gutters/2;
-    $_before: percentage($_split/$_end);
-    $_after: percentage((1 + $_split)/$_end);
-    $_stops: $_trans $_before, $_color $_before, $_light $_after, $_trans $_after;
-  } @else {
-    $_stops: $_color, $_light $_after, $_trans $_after;
-  }
-
-  @if $_math == static {
-    $_size: valid-column-math($_math, $_column-width) * $_end;
-  }
-
-  $_output: (
-    image: (columns: $_stops),
-    size: $_size,
-  );
-
-  @return $_output;
-}
-
-
-// Get Asymmetrical Inside
-// -----------------------
-// - $grid: <settings>
-@function get-asym-inside(
-  $grid
-) {
-  $grid     : parse-grid($grid);
-  $_columns : susy-get(columns, $grid);
-
-  $_color   : debug-get(color);
-  $_light   : lighten($_color, 15%);
-  $_stops   : ();
-
-  @for $location from 1 through susy-count($_columns) {
-    $this-stop: ();
-
-    @if $location == 1 {
-      $this-stop: append($this-stop, $_color, comma);
-    } @else {
-      $start: parse-span(1 at $location $grid);
-      $start: get-isolation($start);
-      $this-stop: append($this-stop, $_color $start, comma);
-    }
-
-    @if $location == susy-count($_columns) {
-      $this-stop: append($this-stop, $_light, comma);
-    } @else {
-      $_end: parse-span(1 at ($location + 1) $grid);
-      $_end: get-isolation($_end);
-      $this-stop: append($this-stop, $_light $_end, comma);
-    }
-
-    $_stops: join($_stops, $this-stop, comma);
-  }
-
-  @return $_stops;
-}
-
-
-// Get Asymmetrical Split
-// ----------------------
-// - $grid: <settings>
-@function get-asym-split(
-  $grid
-) {
-  $grid     : parse-grid($grid);
-  $_columns : susy-get(columns, $grid);
-
-  $_color   : debug-get(color);
-  $_light   : lighten($_color, 15%);
-  $_stops   : ();
-
-  @for $location from 1 through susy-count($_columns) {
-    $this-stop: ();
-
-    $start: parse-span(1 at $location $grid);
-    $start: get-isolation($start);
-    $this-stop: append($this-stop, transparent $start, comma);
-    $this-stop: append($this-stop, $_color $start, comma);
-
-    $_end: $start + span(1 at $location $grid);
-    $this-stop: append($this-stop, $_light $_end, comma);
-    $this-stop: append($this-stop, transparent $_end, comma);
-
-    $_stops: join($_stops, $this-stop, comma);
-  }
-
-  @return $_stops;
-}
-
-
-// Get Asymmetrical Outside
-// ------------------------
-// - $grid: <settings>
-@function get-asym-outside(
-  $grid
-) {
-  $grid     : parse-grid($grid);
-  $_columns : susy-get(columns, $grid);
-
-  $_color   : debug-get(color);
-  $_light   : lighten($_color, 15%);
-  $_trans   : transparent;
-  $_stops   : ();
-
-  @for $location from 1 through susy-count($_columns) {
-    $this-stop: ();
-
-    @if $location == 1 {
-      $this-stop: append($this-stop, $_color, comma);
-    } @else {
-      $start: parse-span(1 at $location $grid);
-      $start: get-isolation($start);
-      $this-stop: append($this-stop, $_color $start, comma);
-    }
-
-    @if $location == susy-count($_columns) {
-      $this-stop: append($this-stop, $_light, comma);
-    } @else {
-      $gutter: get-span-width(first $location $grid);
-
-      $_end: parse-span(1 at ($location + 1) $grid);
-      $_end: get-isolation($_end);
-
-      $gutter: $_light $gutter, $_trans $gutter, $_trans $_end;
-      $this-stop: join($this-stop, $gutter, comma);
-    }
-
-    $_stops: join($_stops, $this-stop, comma);
-  }
-
-  @return $_stops;
-}
-
-
-// Get Asymmetrical Background
-// ---------------------------
-// - $grid: <settings>
-@function get-background-asym(
-  $grid
-) {
-  $_stops: ();
-
-  @if is-inside($grid) {
-    $_stops: get-asym-inside($grid);
-  } @else if is-split($grid) {
-    $_stops: get-asym-split($grid);
-  } @else {
-    $_stops: get-asym-outside($grid);
-  }
-
-  @return (image: (columns: $_stops));
-}
-
-
-// Get Background
-// --------------
-// - $grid: <settings>
-@function get-background(
-  $grid
-) {
-  $grid     : parse-grid($grid);
-  $_show    : susy-get(debug image, $grid);
-  $_return  : ();
-
-  @if $_show and $_show != hide {
-    $_line-height: variable-exists(base-line-height);
-    $_line-height: if($_line-height, $base-line-height, false);
-    $_columns: susy-get(columns, $grid);
-
-    @if $_show != show-baseline {
-      $_sym: is-symmetrical($_columns);
-      $_return: if($_sym, get-background-sym($grid), get-background-asym($grid));
-      $_return: map-merge($_return, (clip: content-box));
-    } @else if not($_line-height) {
-      @warn 'Please provide $base-line-height in order to see baseline grids.';
-    }
-
-    @if $_line-height {
-      @if $_show != show-columns {
-        $_color: variable-exists(grid-background-baseline-color);
-        $_color: if($_color, $grid-background-baseline-color, #000);
-
-        $_image: map-get($_return, image);
-        $_size: map-get($_return, size);
-        $_baseline: (baseline: ($_color 1px, transparent 1px));
-        $_baseline-size: 100% $_line-height;
-
-        $_return: map-merge($_return, (
-          image: if($_image, map-merge($_image, $_baseline), $_baseline),
-          size: if($_size, ($_size, $_baseline-size), $_baseline-size),
-        ));
-      }
-
-      @if $_show == show {
-        $_clip: map-get($_return, clip);
-        $_return: map-merge($_return, (clip: join($_clip, border-box, comma)));
-      }
-    }
-  }
-
-  @if map-get($_return, image) {
-    $_return: map-merge($_return, (flow: susy-get(flow, $grid)));
-  }
-
-  @return $_return;
 }
 
 

--- a/sass/susy/language/susy/_background.scss
+++ b/sass/susy/language/susy/_background.scss
@@ -35,7 +35,7 @@ $susy-overlay-grid-head-exists: false;
 @mixin background-grid(
   $grid: $susy
 ) {
-  
+  $grid: layout($grid);
   $colums-count: susy-count(  susy-get(columns, $grid));
   $debug-color: susy-get(debug color, $grid);
   $debug-color-light: lighten($debug-color,10) ;

--- a/sass/susy/su/_utilities.scss
+++ b/sass/susy/su/_utilities.scss
@@ -123,21 +123,11 @@
 
 @function str-replace($string, $search, $replace: '') {
   $index: str-index($string, $search);
-  
-  @if $index {
-    @return str-slice($string, 1, $index - 1) + $replace + str-replace(str-slice($string, $index + str-length($search)), $search, $replace);
-  }
-  
-  @return $string;
-}
-@function str-replace($string, $search, $replace: '') {
-  $index: str-index($string, $search);
   @if $index {
     @return str-slice($string, 1, $index - 1) + $replace + str-replace(str-slice($string, $index + str-length($search)), $search, $replace);
   }
   @return $string;
 }
-
 
 // HTML-Encode 
 // ------------

--- a/sass/susy/su/_utilities.scss
+++ b/sass/susy/su/_utilities.scss
@@ -109,3 +109,45 @@
 
   @return $_return;
 }
+
+
+
+// str-replace 
+// ------------
+// by Hugo Giraudel
+// Replace `$search` with `$replace` in `$string`
+// @param {String} $string - Initial string
+// @param {String} $search - Substring to replace
+// @param {String} $replace ('') - New value
+// @return {String} - Updated string
+
+@function str-replace($string, $search, $replace: '') {
+  $index: str-index($string, $search);
+  
+  @if $index {
+    @return str-slice($string, 1, $index - 1) + $replace + str-replace(str-slice($string, $index + str-length($search)), $search, $replace);
+  }
+  
+  @return $string;
+}
+@function str-replace($string, $search, $replace: '') {
+  $index: str-index($string, $search);
+  @if $index {
+    @return str-slice($string, 1, $index - 1) + $replace + str-replace(str-slice($string, $index + str-length($search)), $search, $replace);
+  }
+  @return $string;
+}
+
+
+// HTML-Encode 
+// ------------
+// returns a url-encoded string
+
+
+@function html-encode($string){
+  $encodeMap:("%":"%25"," ":"%20","!":"%21","\"":"%22","#":"%23","$":"%24","&":"%26","\'":"%27","(":"%28",")":"%29","*":"%2A","+":"%2B",",":"%2C","-":"%2D",".":"%2E","/":"%2F",":":"%3A",";":"%3B","<":"%3C","=":"%3D",">":"%3E","?":"%3F","@":"%40","[":"%5B","\\":"%5C","]":"%5D","^":"%5E","_":"%5F","`":"%60","{":"%7B","|":"%7C","}":"%7D","~":"%7E","¢":"%A2","£":"%A3","¥":"%A5","§":"%A7","«":"%AB","¬":"%AC","¯":"%AD","º":"%B0","±":"%B1","ª":"%B2","µ":"%B5","»":"%BB","¼":"%BC","½":"%BD","¿":"%BF","À":"%C0","Á":"%C1","Â":"%C2","Ã":"%C3","Ä":"%C4","Å":"%C5","Æ":"%C6","Ç":"%C7","È":"%C8","É":"%C9","Ê":"%CA","Ë":"%CB","Ì":"%CC","Í":"%CD","Î":"%CE","Ï":"%CF","Ð":"%D0","Ñ":"%D1","Ò":"%D2","Ó":"%D3","Ô":"%D4","Õ":"%D5","Ö":"%D6","Ø":"%D8","Ù":"%D9","Ú":"%DA","Û":"%DB","Ü":"%DC","Ý":"%DD","Þ":"%DE","ß":"%DF","à":"%E0","á":"%E1","â":"%E2","ã":"%E3","ä":"%E4","å":"%E5","æ":"%E6","ç":"%E7","è":"%E8","é":"%E9","ê":"%EA","ë":"%EB","ì":"%EC","í":"%ED","î":"%EE","ï":"%EF","ð":"%F0","ñ":"%F1","ò":"%F2","ó":"%F3","ô":"%F4","õ":"%F5","ö":"%F6","÷":"%F7","ø":"%F8","ù":"%F9","ú":"%FA","û":"%FB","ü":"%FC","ý":"%FD","þ":"%FE","ÿ":"%FF");
+  @each $search, $replace in $encodeMap {
+    $string:  str-replace($string, $search, $replace);
+  }
+  @return $string;
+}


### PR DESCRIPTION
Replacing the Gradient Background with a Generated SVG results in a more precise preview-grid.

This ist a Modified version of Dennis de Goedes method for dynamic SVG Backgrounds:
http://blog.trifork.com/2014/05/14/advanced-theming-dynamic-svg-backgrounds-with-sass-the-right-way/

Utilitzing a string-Replace methos by by Hugo Giraudel I encode the raw SVG after generating it. This ensure compatibility with Firefox and IE.

This is a quiet massive change. New Tests have to be written.

Signed-off-by: Michael Gehrmann <m@g12n.de>