### PR TITLE
Fix box-sizing deprecation warning

### DIFF
--- a/sass/susy/output/support/_box-sizing.scss
+++ b/sass/susy/output/support/_box-sizing.scss
@@ -8,10 +8,12 @@
 @mixin susy-box-sizing(
   $model: content-box
 ) {
-  @if susy-support(box-sizing, (mixin: box-sizing), $warn: false) {
-    @include box-sizing($model);
-  } @else {
-    $prefix: (moz, webkit, official);
-    @include susy-prefix(box-sizing, $model, $prefix);
+  @if $model {
+    @if susy-support(box-sizing, (mixin: box-sizing), $warn: false) {
+      @include box-sizing($model);
+    } @else {
+      $prefix: (moz, webkit, official);
+      @include susy-prefix(box-sizing, $model, $prefix);
+    }
   }
 }


### PR DESCRIPTION
Do not try to output any box-sizing if no $model (null, false) is passed in. This does at least happen in `_span.scss`, where it could be fixed instead, too. Not all `box-sizing` mixins handle `null` well: Compass' mixin unquotes `null` in that case which currently generates a deprecation warning in Sass. This avoids the need for `use-custom: (box-sizing: false)` when using `global-box-sizing: border-box` and should close #425.
