### PR TITLE
fix segmentation fail for node-sass 3.4.2

### DIFF
--- a/sass/susy/output/shared/_inspect.scss
+++ b/sass/susy/output/shared/_inspect.scss
@@ -10,7 +10,7 @@
 @mixin susy-inspect($mixin, $inspect...) {
   $show: false;
 
-  @each $item in $inspect {
+  @each $item in join($inspect, ()) {
     @if index($item, inspect) {
       $show: true;
     }


### PR DESCRIPTION
I got "segmentation fault"  error with `node-sass@3.4.2`.
And try to avoid this error.