### PR TITLE
Added $pixel-values-only to prevent setting rem values in susyone.

### DIFF
--- a/sass/susy/language/susyone/_grid.scss
+++ b/sass/susy/language/susyone/_grid.scss
@@ -22,17 +22,33 @@
 //  $columns  : The number of columns in the Grid Layout.
 @mixin set-container-width(
   $columns  : $total-columns,
-  $style    : $container-style
+  $style    : $container-style,
+  $px-vals  : $pixel-values-only
 ){
   $width: container-outer-width($columns);
 
   @if $style == 'static' {
-    @include rem(width, $width);
+    @if $px-vals == true {
+      width: round(convert-length($width, px));
+    } @else {
+      @include rem(width, $width);
+    }
   } @else {
     @if $style == 'fluid' {
-      @if unit($width) == '%' { @include rem(width, $width); }
+      @if unit($width) == '%' {
+        @if $px-vals == true {
+          width: round(convert-length($width, px));
+        } @else {
+          @include rem(width, $width);
+        }
+      }
     } @else {
-      @include rem(max-width, $width);
+      @if $px-vals == true {
+        max-width: round(convert-length($width, px));
+      } @else {
+        @include rem(max-width, $width);
+      }
+
       @include for-legacy-browser(ie,"6") {
         @if unit($width) == 'rem' {
           _width: round(convert-length($width, px));
@@ -48,12 +64,18 @@
 //
 //  $columns  : The number of columns in the container.
 @mixin apply-container(
-  $columns  : $total-columns
+  $columns  : $total-columns,
+  $px-vals  : $pixel-values-only
 ){
   @include pie-clearfix;
   @include set-container-width($columns);
-  @include rem(padding-left, $grid-padding);
-  @include rem(padding-right, $grid-padding);
+  @if $px-vals == true {
+    padding-left: round(convert-length($grid-padding, px));
+    padding-right: round(convert-length($grid-padding, px));
+  } @else {
+    @include rem(padding-left, $grid-padding);
+    @include rem(padding-right, $grid-padding);
+  }
   margin: { left: auto; right: auto; }
 }
 

--- a/sass/susy/language/susyone/_settings.scss
+++ b/sass/susy/language/susyone/_settings.scss
@@ -42,6 +42,10 @@ $container-style    : magic           !default;
 // and simply apply the border-box-sizing mixin.
 $border-box-sizing  : false           !default;
 
+// Pixel Values only:
+// Make sure only pixel values are set for the container width.
+$pixel-values-only  : false           !default;
+
 // ---------------------------------------------------------------------------
 // IE Settings
 

--- a/test/css/test-susyone.css
+++ b/test/css/test-susyone.css
@@ -315,6 +315,20 @@
   margin-left: 8.47458%;
   margin-right: 8.47458%; }
 
+/* ---------------------------------------------------------------------------
+/* Pixel-Values only */
+.container {
+  *zoom: 1;
+  width: 944px;
+  padding-left: 16px;
+  padding-right: 16px;
+  margin-left: auto;
+  margin-right: auto; }
+  .container:after {
+    content: "";
+    display: table;
+    clear: both; }
+
 .isolate {
   margin-right: -100%;
   margin-left: 16.94915%; }

--- a/test/scss/language/susyone/_grid.scss
+++ b/test/scss/language/susyone/_grid.scss
@@ -73,4 +73,16 @@ $container-style: static;
   $container-width: false !global;
 }
 
+
+/* ---------------------------------------------------------------------------
+/* Pixel-Values only */
+
+$pixel-values-only: true;
+
+.container {
+  @include container;
+}
+
+$pixel-values-only: false;
 $container-style: magic;
+


### PR DESCRIPTION
See #554. 

Default value for the setting is `false` to keep the current behaviour.