### PR TITLE
#{} interpolation deprecation warning in _support.scss

### DIFF
--- a/sass/susy/output/support/_support.scss
+++ b/sass/susy/output/support/_support.scss
@@ -67,7 +67,7 @@
 
     @each $_type, $_req in $requirements {
       @each $_i in $_req {
-        $_pass: call(#{$_type}-exists, $_i);
+        $_pass: call(unquote("#{$_type}-exists"), $_i);
 
         @if not($_pass) {
           $_fail: true;


### PR DESCRIPTION
    DEPRECATION WARNING on line 70 of sass/susy/output/support/_support.scss:
    #{} interpolation near operators will be simplified in a future version of Sass.
    To preserve the current behavior, use quotes:

        unquote("#{$_type}-exists")

```bash
$ bundle show                                                   
Gems included by the bundle:
  * bundler (1.11.2)
  * sass (3.4.20)
  * susy (2.2.9)

$ rbenv version
2.2.4 (set by ~/.rbenv/version)
```

PR includes the suggested fix, it's not thoroughly tested.

Thank you.
