### PR TITLE
Fix a typo in docs

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -498,7 +498,7 @@ Set the width of a gutter relative to columns on your grid.
 Column Width
 ------------
 
-Optionaly set the explicit width of a column.
+Optionally set the explicit width of a column.
 
 .. describe:: setting
 


### PR DESCRIPTION
`Optionaly` → `Optionally`