### PR TITLE
Add required eyeglass "needs" option.

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "eyeglass-module"
   ],
   "eyeglass": {
-    "exports": "eyeglass-exports.js"
+    "exports": "eyeglass-exports.js",
+    "needs": "*"
   },
   "scripts": {
     "test": "npm run test-libsass && npm run test-ruby",

--- a/package.json
+++ b/package.json
@@ -23,8 +23,10 @@
     "eyeglass-module"
   ],
   "eyeglass": {
+    "sassDir": "sass",
     "exports": "eyeglass-exports.js",
-    "needs": "*"
+    "name": "susy",
+    "needs": "^1.0.0"
   },
   "scripts": {
     "test": "npm run test-libsass && npm run test-ruby",


### PR DESCRIPTION
Eyeglass 1 is a little finicky about declaring a compatible version.

If you don't require any specific eyeglass features adding a * stops it throwing errors like below:

```
The following modules did not declare an eyeglass version:
  susy
Please add the following to the module's package.json:
  "eyeglass": { "needs": "^1.1.2" }
```