### PR TITLE
Update readme for breaking change for webpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Make sure you have sass-loader enabled in your webpack configuration:
 loaders: [
   {
     test: /\.scss$/,
-    loader: 'style!css!sass'
+    loader: 'style-loader!css-loader!sass-loader'
   }
 ]
 ```


### PR DESCRIPTION
As for webpack, 

```
BREAKING CHANGE: It's no longer allowed to omit the '-loader' suffix when using loaders.
                 You need to specify 'style-loader' instead of 'style',
                 see https://webpack.js.org/guides/migrating/#automatic-loader-module-name-extension-removed
```

We should use `-loader` with loader name.