### PR TITLE
Add Susy.js link to README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ Resources
 - [Changelog](https://github.com/oddbird/susy/blob/master/CHANGELOG.md)
 - [Guidelines for contributing](https://github.com/oddbird/susy/blob/master/CONTRIBUTING.md)
 - [BSD3 License](https://github.com/oddbird/susy/blob/master/LICENSE.txt)
+
+Third-Party Tools
+-----------------
+
 - [Susy.js](https://github.com/ignota/susy.js) CSS-in-JS port
 
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Resources
 - [Changelog](https://github.com/oddbird/susy/blob/master/CHANGELOG.md)
 - [Guidelines for contributing](https://github.com/oddbird/susy/blob/master/CONTRIBUTING.md)
 - [BSD3 License](https://github.com/oddbird/susy/blob/master/LICENSE.txt)
+- [Susy.js](https://github.com/ignota/susy.js) CSS-in-JS port
 
 
 Installation


### PR DESCRIPTION
Hey OddBirds! I'm a longtime Susy enthusiast who's been missing it ever since moving to Styled Components. I recently got a yen to add a real grid system to a project and decided to port your gorgeous math over to a JavaScript bundle that would work with a CSS-in-JS-based stack. So far it has the core API down and a suite of passing integration-level tests based on your Sass tests; I plan on adding the SVG grid plugin and additional unit tests over time.

The point is it seems to work; I've started using it to good effect in production on [Ignota.com](https://ignota.com), and plan to expand its use there as well.

This PR adds a link to the repo to your README, just in case it'd be useful to others. Would love to have folks kick the tires a bit!

Thanks so much for all your hard work on Susy, and for considering my self-aggrandizing little advertorial change. 😬