### PR TITLE
Automatically publish oddleventy docs

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -1,0 +1,54 @@
+name: Publish documentation
+on:
+  release: # Run when stable releases are published
+    types: [released]
+  workflow_dispatch: # Run on-demand
+    inputs:
+      ref:
+        description: Git ref to build docs from
+        required: true
+        default: main
+        type: string
+
+jobs:
+  push-branch:
+    name: Build & push docs
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+    steps:
+      - name: Check out from release
+        if: github.event_name == 'release'
+        uses: actions/checkout@v3
+      - name: Check out from manual input
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.ref }}
+      - uses: actions/setup-node@v3
+        with:
+          version: 6
+          cache: yarn
+      - run: yarn install
+      - run: yarn sassdoc
+      - name: Clone docs branch
+        uses: actions/checkout@v3
+        with:
+          path: docs-branch
+          ref: oddleventy-docs
+      - name: Commit & push to docs branch
+        run: |
+          SHA=$(git rev-parse HEAD)
+          cd docs-branch
+          rm -rf susy/docs
+          mkdir -p susy/docs
+          cp -r ${{ github.workspace }}/docs/ susy/
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git add -A .
+          git commit --allow-empty \
+          -m "Update from https://github.com/${{ github.repository }}/commit/$SHA" \
+          -m "Full log: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          git push origin oddleventy-docs


### PR DESCRIPTION
![](https://source.unsplash.com/featured/?cute,animal&2211044)
<!-- Swap `CHANGE_ME` for a random string to get a different image -->


## Description
Use GH Actions to automatically build and publish documentation on every release.

1. On each stable release the `publish-docs.yml` workflow is called
2. `yarn sassdoc` outputs to the `docs/` folder
3. The `docs/` folder is pushed to the `oddleventy-docs` branch
4. Netlify picks up the new commit on this branch and re-deploys the site at https://susy-docs.netlify.app/susy/docs
5. oddbird.net proxies the Netlify site under the `/susy/docs/` path (after we merge https://github.com/oddbird/oddleventy/pull/268)

I also added the option of running the workflow on demand. This should allow us to rebuild docs without having to create a release.